### PR TITLE
Add RUB selector to the currency selection

### DIFF
--- a/public/flags/RU.svg
+++ b/public/flags/RU.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+    <rect x="0" y="0" width="512" height="170.67" fill="#FFFFFF" />
+    <rect x="0" y="170.67" width="512" height="170.67" fill="#0039A6" />
+    <rect x="0" y="341.33" width="512" height="170.67" fill="#DA0714" />
+</svg>

--- a/src/components/ui/CurrencySelector.tsx
+++ b/src/components/ui/CurrencySelector.tsx
@@ -144,7 +144,7 @@ export function CurrencySelector({ className, onChange }: CurrencySelectorProps)
   const currencyArray = Object.values(SUPPORTED_CURRENCIES)
 
   // Sort currencies to prioritize specific ones in custom order
-  const priorityOrder = ["USD", "PKR", "GBP", "SAR", "INR"];
+  const priorityOrder = ["USD", "PKR", "GBP", "SAR", "INR", "RUB"];
 
   // Sort the currency array based on priority
   const sortedCurrencyArray = [...currencyArray].sort((a, b) => {
@@ -186,7 +186,7 @@ export function CurrencySelector({ className, onChange }: CurrencySelectorProps)
     const isInitialPageLoad = !localStorage.getItem('has-selected-currency');
 
     // Check if this is a page refresh (rather than user interaction)
-    // This is determined by checking if this currency selection is happening 
+    // This is determined by checking if this currency selection is happening
     // during the initial component mount and matches what was previously stored
     const previouslySavedCurrency = localStorage.getItem('selected-currency');
     const isPageRefresh = !isInitialPageLoad &&
@@ -354,4 +354,4 @@ export function CurrencySelector({ className, onChange }: CurrencySelectorProps)
       </div>
     </div>
   )
-} 
+}

--- a/src/lib/utils/currency.ts
+++ b/src/lib/utils/currency.ts
@@ -16,7 +16,8 @@ export const SUPPORTED_CURRENCIES = {
   // Temporarily removed AED until we fix currency conversion issues
   // AED: { code: "AED", locale: "ar-AE", symbol: "د.إ", name: "UAE Dirham" },
   INR: { code: "INR", locale: "en-IN", symbol: "₹", name: "Indian Rupee" },
-  PKR: { code: "PKR", locale: "ur-PK", symbol: "₨", name: "Pakistani Rupee" }
+  PKR: { code: "PKR", locale: "ur-PK", symbol: "₨", name: "Pakistani Rupee" },
+  RUB: {code: "RUB", locale: "ru-RU", symbol: "₽", name: "Russian Ruble"},
 }
 
 export type SupportedCurrency = keyof typeof SUPPORTED_CURRENCIES
@@ -142,4 +143,4 @@ export const isValidCurrencyAmount = (value: number): boolean => {
     isFinite(value) &&
     value >= 0 &&
     value <= Number.MAX_SAFE_INTEGER
-} 
+}

--- a/src/tests/currencyTest.tsx
+++ b/src/tests/currencyTest.tsx
@@ -17,12 +17,12 @@ export default function CurrencySelectorTest() {
   return (
     <div className="flex flex-col gap-6 p-8 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold">Currency Selector Test</h1>
-      
+
       <div className="p-4 border rounded-md bg-slate-50">
         <h2 className="font-medium mb-3">Current Selection</h2>
         <div className="flex flex-col sm:flex-row sm:items-center gap-4">
           <div className="w-full sm:w-[240px]">
-            <CurrencySelector 
+            <CurrencySelector
               value={currency}
               onValueChange={handleCurrencyChange}
             />
@@ -32,12 +32,12 @@ export default function CurrencySelectorTest() {
           </div>
         </div>
       </div>
-      
+
       <div className="p-4 border rounded-md bg-slate-50">
         <h2 className="font-medium mb-3">Test UI</h2>
         <div className="flex gap-2 flex-wrap">
-          {['USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD'].map(code => (
-            <Button 
+          {['USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD', 'RUB'].map(code => (
+            <Button
               key={code}
               variant={currency === code ? "default" : "outline"}
               size="sm"
@@ -48,7 +48,7 @@ export default function CurrencySelectorTest() {
           ))}
         </div>
       </div>
-      
+
       <div className="p-4 border rounded-md bg-slate-50">
         <h2 className="font-medium mb-3">Selection History</h2>
         <div className="text-sm">
@@ -65,8 +65,8 @@ export default function CurrencySelectorTest() {
           )}
         </div>
       </div>
-      
-      <Button 
+
+      <Button
         onClick={() => setSelectedCurrencies([])}
         variant="outline"
       >
@@ -74,4 +74,4 @@ export default function CurrencySelectorTest() {
       </Button>
     </div>
   )
-} 
+}


### PR DESCRIPTION
Currencies are already supported as the types, and conversion API works correctly. 
In this pull request, I added a RUB selector to the list (shown as the second row)

![image](https://github.com/user-attachments/assets/d15edcff-832e-462d-9bb4-26552411785b)
Values are calculated correctly too:
![image](https://github.com/user-attachments/assets/b2fc8f46-5d82-4c39-b975-ef5e97280cfa)

Additionally I investigated the issue with currency conversion:
 * `https://api.frankfurter.app/latest?from=${from}&to=${to}`, doesn't always return values, for example, [for USD/RUB pair](https://api.frankfurter.app/latest?from=USD&to=RUB).
 
 To resolve it, I could manually add the fallback rate, but it would be very error-prone.
 Instead I reused the existing currency state that returns up-to-date values.
