### PR TITLE
Claude/fix currency fallback consistency 01 uj t8c np mcm76 msoofwhgk5

### DIFF
--- a/src/app/api/prices/crypto/route.ts
+++ b/src/app/api/prices/crypto/route.ts
@@ -10,6 +10,68 @@ const IS_REPLIT = typeof window !== 'undefined' &&
   (window.location.hostname.includes('replit') ||
     window.location.hostname.endsWith('.repl.co'));
 
+// Comprehensive fallback exchange rates (approximate values as of 2025)
+// These are used when the Frankfurter API is unavailable
+const FALLBACK_RATES: { [key: string]: number } = {
+  // USD to other currencies
+  'USD-SAR': 3.75,    // Saudi Riyal (fixed peg)
+  'USD-PKR': 278.5,   // Pakistani Rupee
+  'USD-RUB': 91.5,    // Russian Ruble
+  'USD-INR': 84.0,    // Indian Rupee
+  'USD-GBP': 0.79,    // British Pound
+  // GBP to other currencies
+  'GBP-USD': 1.27,    // Inverse of USD-GBP
+  // EUR fallbacks (if needed in the future)
+  'USD-EUR': 0.93,
+  'EUR-USD': 1.08,
+};
+
+// Helper function to get fallback rate
+function getFallbackRate(from: string, to: string): number | null {
+  const fromUpper = from.toUpperCase();
+  const toUpper = to.toUpperCase();
+
+  // Direct lookup
+  const key = `${fromUpper}-${toUpper}`;
+  if (FALLBACK_RATES[key]) {
+    console.log(`Using fallback rate for ${from} to ${to}: ${FALLBACK_RATES[key]}`);
+    return FALLBACK_RATES[key];
+  }
+
+  // Try reverse lookup for inverse rate
+  const reverseKey = `${toUpper}-${fromUpper}`;
+  if (FALLBACK_RATES[reverseKey]) {
+    const inverseRate = 1 / FALLBACK_RATES[reverseKey];
+    console.log(`Using inverse fallback rate for ${from} to ${to}: ${inverseRate}`);
+    return inverseRate;
+  }
+
+  // Try triangulation through USD for cross-currency conversions
+  if (fromUpper !== 'USD' && toUpper !== 'USD') {
+    const fromToUSD = FALLBACK_RATES[`${fromUpper}-USD`];
+    const usdToTo = FALLBACK_RATES[`USD-${toUpper}`];
+
+    if (fromToUSD && usdToTo) {
+      const rate = fromToUSD * usdToTo;
+      console.log(`Using triangulated fallback rate for ${from} to ${to}: ${rate} (via USD)`);
+      return rate;
+    }
+
+    // Try inverse triangulation
+    const usdToFrom = FALLBACK_RATES[`USD-${fromUpper}`];
+    const toToUSD = FALLBACK_RATES[`${toUpper}-USD`];
+
+    if (usdToFrom && toToUSD) {
+      const rate = toToUSD / usdToFrom;
+      console.log(`Using inverse triangulated fallback rate for ${from} to ${to}: ${rate} (via USD)`);
+      return rate;
+    }
+  }
+
+  console.log(`No fallback rate available for ${from} to ${to}`);
+  return null;
+}
+
 // Helper function to get exchange rate with fallbacks
 async function getExchangeRate(from: string, to: string): Promise<number | null> {
   // If currencies are the same, no conversion needed
@@ -29,67 +91,15 @@ async function getExchangeRate(from: string, to: string): Promise<number | null>
       }
     }
 
-    console.log(`Frankfurter API failed for ${from} to ${to}, trying Open Exchange Rates API`);
+    console.log(`Frankfurter API failed for ${from} to ${to}, using fallbacks`);
 
-    // Try Open Exchange Rates API as a fallback
-    try {
-      // Use our proxy endpoint to avoid exposing API keys
-      const openExchangeResponse = await fetch(`/api/proxy/currency?base=${from}&symbols=${to}`);
-
-      if (openExchangeResponse.ok) {
-        const openExchangeData = await openExchangeResponse.json();
-        if (openExchangeData && openExchangeData.rates && openExchangeData.rates[to.toUpperCase()]) {
-          const rate = openExchangeData.rates[to.toUpperCase()];
-          console.log(`Got real-time exchange rate from Open Exchange Rates for ${from} to ${to}: ${rate}`);
-          return rate;
-        }
-      }
-    } catch (openExchangeError) {
-      console.error(`Open Exchange Rates API failed for ${from} to ${to}:`, openExchangeError);
-    }
-
-    console.log(`All API attempts failed for ${from} to ${to}, using fallback rates`);
-
-    // Fallback to hardcoded rates if API fails
-    // Special case for USD to SAR (Saudi Riyal)
-    if (from.toUpperCase() === 'USD' && to.toUpperCase() === 'SAR') {
-      console.log(`Using fallback rate for USD to SAR: 3.75`);
-      return 3.75; // Fixed rate for SAR
-    }
-
-    // Special case for USD to PKR (Pakistani Rupee) - approximate rate
-    if (from.toUpperCase() === 'USD' && to.toUpperCase() === 'PKR') {
-      console.log(`Using fallback rate for USD to PKR: 278.5`);
-      return 278.5; // Approximate rate for PKR
-    }
-
-    // Special case for USD to RUB (Russian Ruble) - approximate rate
-    if (from.toUpperCase() === 'USD' && to.toUpperCase() === 'RUB') {
-      console.log(`Using fallback rate for USD to RUB: 91.5`);
-      return 91.5; // Approximate rate for RUB
-    }
-
-    return null;
+    // Use comprehensive fallback rates
+    return getFallbackRate(from, to);
   } catch (error) {
     console.error(`Error fetching exchange rate from ${from} to ${to}:`, error);
 
-    // Fallback to hardcoded rates if error occurs
-    if (from.toUpperCase() === 'USD' && to.toUpperCase() === 'SAR') {
-      console.log(`Using fallback rate after error for USD to SAR: 3.75`);
-      return 3.75;
-    }
-
-    if (from.toUpperCase() === 'USD' && to.toUpperCase() === 'PKR') {
-      console.log(`Using fallback rate after error for USD to PKR: 278.5`);
-      return 278.5;
-    }
-
-    if (from.toUpperCase() === 'USD' && to.toUpperCase() === 'RUB') {
-      console.log(`Using fallback rate after error for USD to RUB: 91.5`);
-      return 91.5;
-    }
-
-    return null;
+    // Even when an exception occurs, try to use fallback rates
+    return getFallbackRate(from, to);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds internal fallback exchange rate tables and lookup logic to `crypto` and `stocks` price APIs, using Frankfurter first and falling back to inverse/triangulated USD rates.
> 
> - **Exchange Rates & Currency Conversion**:
>   - Add comprehensive fallback FX table and helpers in `src/app/api/prices/crypto/route.ts` and `src/app/api/prices/stocks/route.ts`:
>     - `FALLBACK_RATES` with key pairs like `USD-SAR`, `USD-PKR`, `USD-GBP`, etc.
>     - `getFallbackRate(from, to)` with direct, inverse, and USD-triangulated lookups.
>     - `getExchangeRate(from, to)` that queries Frankfurter first, then falls back to `getFallbackRate`.
> - **APIs**:
>   - Both routes now log and use fallback rates when Frankfurter is unavailable, improving robustness of currency conversion during pricing responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78a61ccecd80fad72f426bed5d51398e8f8c2954. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->